### PR TITLE
Fix warning

### DIFF
--- a/src/commonLib.cpp
+++ b/src/commonLib.cpp
@@ -49,9 +49,9 @@ email:  dtarb@usu.edu
 //==================================
 /*  Nameadd(..)  Utility for adding suffixes to file names prior to
    "." extension   */
-int nameadd(char *full,char *arg,char *suff)
+int nameadd(char *full,char *arg,const char *suff)
 {
-        char *ext, *extsuff;
+        const char *ext, *extsuff;
         long nmain;
     ext=strrchr(arg,'.');
 	extsuff=strrchr(suff,'.');

--- a/src/commonLib.h
+++ b/src/commonLib.h
@@ -88,7 +88,7 @@ const int d2[9] = { 0,0,-1,-1,-1, 0, 1,1,1};
 const double aref[10] = { -atan2((double)1,(double)1), 0., -aref[0],(double)(0.5*PI),PI-aref[2],(double)PI,
                         PI+aref[2],(double)(1.5*PI),2.*PI-aref[2],(double)(2.*PI) };   // DGT is concerned that this assumes square grids.  For different dx and dx needs adjustment
 
-int nameadd( char*,char*,char*);
+int nameadd( char*,char*,const char*);
 double prop( float a, int k);
 int readoutlets(char *outletsfile, int *noutlets, double*& x, double*& y);
 int readoutlets(char *outletsfile, int *noutlets, double*& x, double*& y, int*& id);

--- a/src/shape/cell.cpp
+++ b/src/shape/cell.cpp
@@ -68,7 +68,7 @@ char * cell::StringValue()
 {	if( cellStringValue != NULL )
 		return cellStringValue;
 	else
-		return "";
+		return (char *)"";
 }
 
 int cell::IntegerValue()

--- a/src/shape/item.cpp
+++ b/src/shape/item.cpp
@@ -67,7 +67,7 @@ char * item::StringValue()
 {	if( itemStringValue != NULL )
 		return itemStringValue;
 	else
-		return "";
+		return (char *)"";
 }
 
 int item::IntegerValue()

--- a/src/shape/record.cpp
+++ b/src/shape/record.cpp
@@ -68,7 +68,7 @@ char * record::StringValue()
 {	if( recordStringValue != NULL )
 		return recordStringValue;
 	else
-		return "";
+		return (char *)"";
 }
 
 int record::IntegerValue()


### PR DESCRIPTION
This is attempt to fix GCC warnings, caused by deprecated conversion from constant string to char*. I tested it a bit with Logan dataset and seems all works fine.