### PR TITLE
modified makefile to find location of gdal installation

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -83,9 +83,10 @@ CFLAGS=-g -Wall
 CFLAGS=-g
 LARGEFILEFLAG= -D_FILE_OFFSET_BITS=64
 #INCDIRS=-I/usr/lib/openmpi/include -I/usr/include/gdal
+INCDIRS=`gdal-config --cflags`
 #LIBDIRS=-lgdal
-LDLIBS=-L/usr/local/lib -lgdal
-
+#LDLIBS=-L/usr/local/lib -lgdal
+LDLIBS=`gdal-config --libs`
 
 #Rules: when and how to make a file
 all : ../areadinf ../aread8 ../moveoutletstostrm ../dropanalysis ../streamnet ../gridnet ../dinfflowdir ../d8flowdir ../d8flowpathextremeup ../d8hdisttostrm ../dinfavalanche ../dinfconclimaccum ../dinfdecayaccum ../dinfdistdown ../dinfdistup ../dinfrevaccum ../dinftranslimaccum ../dinfupdependence ../lengtharea ../peukerdouglas ../pitremove ../slopearea ../slopearearatio ../slopeavedown ../threshold ../twi ../gagewatershed ../connectdown clean 


### PR DESCRIPTION
The code failed to compile when I installed gdal in a custom location. As such, I modified the makefile to find the installed location of gdal instead of using the default system install location.