### PR TITLE
Add quotes to CXX Flag variables to fix failing MacOS compilation.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,8 +51,8 @@ set (SINMAPSI SinmapSImn.cpp SinmapSI.cpp ${common_srcs})
 # MPI is required
 find_package(MPI REQUIRED)
 include_directories(${MPI_INCLUDE_PATH})
-set(CMAKE_CXX_FLAG ${CMAKE_CXX_FLAG} ${MPI_COMPILE_FLAGS})
-set(CMAKE_CXX_LINK_FLAGS ${CMAKE_CXX_LINK_FLAGS} ${MPI_LINK_FLAGS})
+set(CMAKE_CXX_FLAG "${CMAKE_CXX_FLAG} ${MPI_COMPILE_FLAGS}")
+set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${MPI_LINK_FLAGS}")
 
 # GDAL is required
 find_package(GDAL REQUIRED)


### PR DESCRIPTION
While updating the Homebrew Formula for building TauDEM on MacOS, we ran into the following compilation error. As reported in osgeo/homebrew-osgeo4mac#216:

```
[ 14%] Linking CXX executable dinfavalanche
/usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_link_script CMakeFiles/dinfavalanche.dir/link.txt --verbose=1
/usr/local/Homebrew/Library/Homebrew/shims/super/clang++  -I/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home/include/darwin -DNDEBUG -Wl,-search_paths_first -Wl,-headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib -L/usr/local/Cellar/open-mpi/3.0.1/lib  CMakeFiles/dinfavalanche.dir/DinfAvalanche.cpp.o CMakeFiles/dinfavalanche.dir/DinfAvalanchemn.cpp.o CMakeFiles/dinfavalanche.dir/commonLib.cpp.o CMakeFiles/dinfavalanche.dir/tiffIO.cpp.o  -o dinfavalanche /usr/local/lib/libmpi_cxx.dylib /usr/local/lib/libmpi.dylib /usr/local/opt/gdal2/lib/libgdal.dylib
[ 15%] Linking CXX executable slopeavedown
/usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_link_script CMakeFiles/slopeavedown.dir/link.txt --verbose=1
/usr/local/Homebrew/Library/Homebrew/shims/super/clang++  -I/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home/include/darwin -DNDEBUG -Wl,-search_paths_first -Wl,-headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib -L/usr/local/Cellar/open-mpi/3.0.1/lib  CMakeFiles/slopeavedown.dir/SlopeAveDown.cpp.o CMakeFiles/slopeavedown.dir/SlopeAveDownmn.cpp.o CMakeFiles/slopeavedown.dir/commonLib.cpp.o CMakeFiles/slopeavedown.dir/tiffIO.cpp.o  -o slopeavedown /usr/local/lib/libmpi_cxx.dylib /usr/local/lib/libmpi.dylib /usr/local/opt/gdal2/lib/libgdal.dylib
ld: unknown option: -headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [threshold] Error 1
make[1]: *** [CMakeFiles/threshold.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
ld: unknown option: -headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [slopearearatio] Error 1
make[1]: *** [CMakeFiles/slopearearatio.dir/all] Error 2
ld: unknown option: -headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [dinfavalanche] Error 1
make[1]: *** [CMakeFiles/dinfavalanche.dir/all] Error 2
ld: unknown option: -headerpad_max_install_names;-L/usr/local/Cellar/libevent/2.1.8/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [slopeavedown] Error 1
make[1]: *** [CMakeFiles/slopeavedown.dir/all] Error 2
make: *** [all] Error 2
```

Following the recommendation in ssolo/ALE@2832cf63a6d822af5957417670b729c6a1301e80, I've patched the CMakeLists to wrap the flag settings in double quotes, which resolves the issue.