### PR TITLE
Enable streamnet not writing tree, coord, or net files

### DIFF
--- a/src/streamnet.cpp
+++ b/src/streamnet.cpp
@@ -1136,7 +1136,12 @@ int netsetup(char *pfile,char *srcfile,char *ordfile,char *ad8file,char *elevfil
 		long treeBuf[9];
 
 		int ilink, ipoint;
-		if(rank==0){//open output point file
+		if( treefile[0] == '\0' || coordfile[0] == '\0' || streamnetsrc[0] == '\0' ) {
+			if ( rank == 0 ) {
+				printf("Not writing tree, coord, or net files (specify all three to write).\n");
+				fflush(stdout);
+			}
+		} else if(rank==0){//open output point file
 			FILE *fTreeOut;
 			fTreeOut = fopen(treefile,"w");// process 0 writes all of its stuff
 			FILE *fout;

--- a/src/streamnetmn.cpp
+++ b/src/streamnetmn.cpp
@@ -50,8 +50,11 @@ email:  dtarb@usu.edu
 
 int main(int argc,char **argv)
 {
-   char pfile[MAXLN],srcfile[MAXLN],ordfile[MAXLN],ad8file[MAXLN],elevfile[MAXLN],wfile[MAXLN],outletsds[MAXLN],lyrname[MAXLN],streamnetsrc[MAXLN];
-   char treefile[MAXLN],coordfile[MAXLN];char streamnetlyr[MAXLN]="";
+   char pfile[MAXLN],srcfile[MAXLN],ordfile[MAXLN],ad8file[MAXLN],elevfile[MAXLN],wfile[MAXLN],outletsds[MAXLN],lyrname[MAXLN];
+   char treefile[MAXLN] = "";
+   char coordfile[MAXLN] = "";
+   char streamnetsrc[MAXLN] = "";
+   char streamnetlyr[MAXLN] = "";
    long ordert=1, useoutlets=0,uselayername=0,lyrno=0; 
    int err,i;
     bool verbose=false;  //  Initialize verbose flag
@@ -242,7 +245,7 @@ int main(int argc,char **argv)
 		nameadd(treefile,argv[1],"tree.txt");
 		nameadd(coordfile,argv[1],"coord.txt");
 		nameadd(wfile,argv[1],"w");
-		//nameadd(streamnetshp,argv[1],"net.shp");
+		nameadd(streamnetsrc,argv[1],"net.shp");
 	} 
 
     if(err=netsetup(pfile,srcfile,ordfile,ad8file,elevfile,treefile,coordfile,outletsds,lyrname,uselayername,lyrno,wfile,streamnetsrc,streamnetlyr,useoutlets, ordert,verbose) != 0)


### PR DESCRIPTION
When specific file names are provided on streamnet command line,
do not write tree, coord, or net files unless all three are given.

These files cannot be written in parallel or directly to cloud storage,
so it can be useful to omit them when writing rasters in VRT format.

Also fix simple usage (without specific file names) net file output.