### PR TITLE
linearpart.h: Handle NaN NoData properly

### DIFF
--- a/src/linearpart.h
+++ b/src/linearpart.h
@@ -62,6 +62,7 @@ class linearpart : public tdpartition {
 		int rank, size;
 		MPI_Datatype MPI_type;
 		datatype noData;
+		bool isNodataNan;
 		datatype *gridData;
 		datatype *topBorder;
 		datatype *bottomBorder;
@@ -136,6 +137,7 @@ void linearpart<datatype>::init(long totalx, long totaly, double dx_in, double d
 	dyA = dy_in;
 	MPI_type = MPIt;
 	noData = nd;
+	isNodataNan = isnan(noData);
 
 	//Allocate memory for data and fill with noData value.  Catch exceptions
 	uint64_t prod;  //   use long 64 bit number to hold the product to allocate
@@ -473,11 +475,11 @@ bool linearpart<datatype>::isNodata(long inx, long iny){
 	x = inx;
 	y = iny;
 //DGT to avoid nested calls and type inconsistency
-	if(x>=0 && x<nx && y>=0 && y<ny)return (abs((float)(gridData[x+y*nx]-noData))<MINEPS);  
-//	if(isInPartition(x,y)) return (abs(gridData[x+y*nx]-noData)<MINEPS);
+	if(x>=0 && x<nx && y>=0 && y<ny)return (isNodataNan && isnan(gridData[x+y*nx])) || (!isNodataNan && abs((float)(gridData[x+y*nx]-noData))<MINEPS);
+//	if(isInPartition(x,y)) return (isNodataNan && isnan(gridData[x+y*nx])) || (!isNodataNan && abs(gridData[x+y*nx]-noData)<MINEPS);
 	else if(x>=0 && x<nx){
-		if(y==-1) return (abs((float)(topBorder[x]-noData))<MINEPS);
-		else if(y==ny) return (abs((float)(bottomBorder[x]-noData))<MINEPS);
+		if(y==-1) return (isNodataNan && isnan(topBorder[x])) || (!isNodataNan && abs((float)(topBorder[x]-noData))<MINEPS);
+		else if(y==ny) return (isNodataNan && isnan(bottomBorder[x])) || (!isNodataNan && abs((float)(bottomBorder[x]-noData))<MINEPS);
 	}
 	return true;
 }


### PR DESCRIPTION
This PR fixes handling of NoData that is NaN. Subtracting a NaN value from a non-NaN value yields NaN and comparing this result with `MINEPS` will always return `false` _because comparisons on NaN do not produce a signal_ ([Not-a-Number](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0100r2.html#NaN)).

Testing code:
```c++
#include <math.h>
#include <cstdio>

#define MINEPS 1e-30

int main()
{
    bool isNoData;
    double noData = NAN;

    // this cell is NoData
    double noDataCell = NAN;
    // this cell is not NoData
    double dataCell = 123;

    //---------------------------------------------------------
    printf("## Before this PR\n");
    printf("* no data cell:\t");
    isNoData = abs(noDataCell - noData) < MINEPS;
    if (isNoData)
        // expected output
        printf("NoData\n");
    else
        // actual output
        printf("Not NoData (incorrect)\n");

    printf("* data cell:\t");
    isNoData = abs(dataCell - noData) < MINEPS;
    if (isNoData)
        printf("NoData\n");
    else
        // expected and actual output
        printf("Not NoData (correct)\n");
    printf("\n");

    //---------------------------------------------------------
    printf("## After this PR\n");
    printf("* no data cell:\t");
    isNoData = (isnan(noData) && isnan(noDataCell)) ||
               (!isnan(noData) && abs(noDataCell - noData) < MINEPS);
    if (isNoData)
        // expected and actual output
        printf("NoData (correct)\n");
    else
        printf("Not NoData\n");

    printf("* data cell:\t");
    isNoData = (isnan(noData) && isnan(dataCell)) ||
               (!isnan(noData) && abs(dataCell - noData) < MINEPS);
    if (isNoData)
        printf("NoData\n");
    else
        // expected and actual output
        printf("Not NoData (correct)\n");
}
```
Result:
```bash
$ c++ -o test test.cpp -Wall; ./test
## Before this PR
* no data cell: Not NoData (incorrect)
* data cell:    Not NoData (correct)

## After this PR
* no data cell: NoData (correct)
* data cell:    Not NoData (correct)
```